### PR TITLE
feat: add MiniMax as built-in LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Complete project-level management panel for easier MCP project management at bot
 
 ![](./icons/openmcp.management.png)
 
-Supports multiple large models
+Supports multiple large models: DeepSeek, OpenAI, Qwen, Gemini, Grok, Mistral, MiniMax, Groq, Perplexity, Kimi, Ollama, OpenRouter and more.
 
 ![](./icons/openmcp.support.llm.png)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -39,7 +39,7 @@
 
 ![](./icons/openmcp.management.png)
 
-支持多种大模型
+支持多种大模型：DeepSeek、OpenAI、通义千问、Gemini、Grok、Mistral、MiniMax、Groq、Perplexity、Kimi、Ollama、OpenRouter 等。
 
 ![](./icons/openmcp.support.llm.png)
 

--- a/service/package.json
+++ b/service/package.json
@@ -17,7 +17,9 @@
 		"clean": "rm -rf dist",
 		"lint": "eslint src --ext .ts,.tsx",
 		"typecheck": "tsc --noEmit",
-		"test:storage": "tsx src/common/json-archive-store.test.ts"
+		"test:storage": "tsx src/common/json-archive-store.test.ts",
+		"test:llm": "tsx src/hook/llm.test.ts",
+		"test:llm:integration": "tsx src/hook/llm.integration.test.ts"
 	},
 	"author": "LSTM-Kirigaya",
 	"license": "MIT",

--- a/service/src/hook/llm.integration.test.ts
+++ b/service/src/hook/llm.integration.test.ts
@@ -1,0 +1,143 @@
+/**
+ * MiniMax LLM integration tests
+ * Tests that the MiniMax API endpoint is reachable and the OpenAI-compatible
+ * SDK works correctly with MiniMax's /v1/chat/completions endpoint.
+ *
+ * Requires: MINIMAX_API_KEY environment variable
+ * Run: MINIMAX_API_KEY=<key> npx tsx src/hook/llm.integration.test.ts
+ */
+import { OpenAI } from 'openai';
+import { llms } from './llm.js';
+
+const API_KEY = process.env.MINIMAX_API_KEY;
+if (!API_KEY) {
+	console.log('SKIP: MINIMAX_API_KEY not set, skipping integration tests');
+	process.exit(0);
+}
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, msg: string) {
+	if (condition) {
+		passed++;
+	} else {
+		failed++;
+		console.error(`FAIL: ${msg}`);
+	}
+}
+
+const minimax = llms.find(l => l.id === 'minimax');
+if (!minimax) {
+	console.error('FAIL: minimax provider not found');
+	process.exit(1);
+}
+
+const client = new OpenAI({
+	baseURL: minimax.baseUrl,
+	apiKey: API_KEY
+});
+
+// ── Test 1: Non-streaming chat completion ────────────────────────────
+
+async function testNonStreaming() {
+	console.log('Test 1: Non-streaming chat completion...');
+	const response = await client.chat.completions.create({
+		model: 'MiniMax-M2.7-highspeed',
+		messages: [
+			{ role: 'user', content: 'Say "hello" and nothing else.' }
+		],
+		temperature: 0.1,
+		stream: false
+	});
+
+	const content = response.choices?.[0]?.message?.content ?? '';
+	assert(content.length > 0, 'non-streaming response should have content');
+	assert(response.choices.length > 0, 'response should have at least one choice');
+	console.log(`  Response: "${content.substring(0, 80)}"`);
+}
+
+// ── Test 2: Streaming chat completion ────────────────────────────────
+
+async function testStreaming() {
+	console.log('Test 2: Streaming chat completion...');
+	const stream = await client.chat.completions.create({
+		model: 'MiniMax-M2.7-highspeed',
+		messages: [
+			{ role: 'user', content: 'Count from 1 to 3.' }
+		],
+		temperature: 0.1,
+		stream: true
+	});
+
+	let chunks = 0;
+	let fullContent = '';
+	for await (const chunk of stream) {
+		chunks++;
+		const delta = chunk.choices?.[0]?.delta?.content;
+		if (delta) fullContent += delta;
+	}
+
+	assert(chunks > 0, 'streaming should produce at least one chunk');
+	assert(fullContent.length > 0, 'streaming should produce non-empty content');
+	console.log(`  Got ${chunks} chunks, content: "${fullContent.substring(0, 80)}"`);
+}
+
+// ── Test 3: Tool calling support ─────────────────────────────────────
+
+async function testToolCalling() {
+	console.log('Test 3: Tool calling support...');
+	const response = await client.chat.completions.create({
+		model: 'MiniMax-M2.7-highspeed',
+		messages: [
+			{ role: 'user', content: 'What is the weather in Tokyo?' }
+		],
+		tools: [
+			{
+				type: 'function',
+				function: {
+					name: 'get_weather',
+					description: 'Get the current weather in a given location',
+					parameters: {
+						type: 'object',
+						properties: {
+							location: {
+								type: 'string',
+								description: 'The city name, e.g. Tokyo'
+							}
+						},
+						required: ['location']
+					}
+				}
+			}
+		],
+		temperature: 0.1,
+		stream: false
+	});
+
+	const msg = response.choices?.[0]?.message;
+	const hasToolCall = msg?.tool_calls && msg.tool_calls.length > 0;
+	assert(hasToolCall === true, 'response should include a tool call');
+	if (hasToolCall) {
+		const toolCall = msg!.tool_calls![0];
+		assert(toolCall.function.name === 'get_weather', 'tool call should be get_weather');
+		console.log(`  Tool call: ${toolCall.function.name}(${toolCall.function.arguments})`);
+	}
+}
+
+// ── Run all tests ────────────────────────────────────────────────────
+
+async function run() {
+	await testNonStreaming();
+	await testStreaming();
+	await testToolCalling();
+
+	console.log(`\nMiniMax integration tests: ${passed} passed, ${failed} failed`);
+	if (failed > 0) process.exit(1);
+	else console.log('All integration tests passed!');
+}
+
+run().catch(err => {
+	console.error('Integration test error:', err.message || err);
+	process.exit(1);
+});

--- a/service/src/hook/llm.test.ts
+++ b/service/src/hook/llm.test.ts
@@ -1,0 +1,80 @@
+/**
+ * LLM provider registry tests
+ * Validates that all providers in the llms array are correctly configured,
+ * with specific focus on the MiniMax provider entry.
+ *
+ * Run: npx tsx src/hook/llm.test.ts
+ */
+import { llms } from './llm.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, msg: string) {
+	if (condition) {
+		passed++;
+	} else {
+		failed++;
+		console.error(`FAIL: ${msg}`);
+	}
+}
+
+// ── General provider validation ──────────────────────────────────────
+
+assert(Array.isArray(llms) && llms.length > 0, 'llms should be a non-empty array');
+
+const ids = llms.map(l => l.id);
+const uniqueIds = new Set(ids);
+assert(ids.length === uniqueIds.size, 'all provider ids should be unique');
+
+for (const llm of llms) {
+	assert(typeof llm.id === 'string' && llm.id.length > 0, `provider ${llm.id} should have non-empty id`);
+	assert(typeof llm.name === 'string' && llm.name.length > 0, `provider ${llm.id} should have non-empty name`);
+	assert(typeof llm.baseUrl === 'string' && llm.baseUrl.length > 0, `provider ${llm.id} should have non-empty baseUrl`);
+	assert(Array.isArray(llm.models), `provider ${llm.id} should have models array`);
+	assert(llm.isOpenAICompatible === true, `provider ${llm.id} should be OpenAI compatible`);
+	assert(typeof llm.description === 'string' && llm.description.length > 0, `provider ${llm.id} should have description`);
+	assert(typeof llm.website === 'string', `provider ${llm.id} should have website`);
+	assert(typeof llm.userToken === 'string', `provider ${llm.id} should have userToken`);
+}
+
+// ── MiniMax provider specific tests ──────────────────────────────────
+
+const minimax = llms.find(l => l.id === 'minimax');
+assert(minimax !== undefined, 'minimax provider should exist');
+
+if (minimax) {
+	assert(minimax.name === 'MiniMax', 'minimax name should be "MiniMax"');
+	assert(minimax.baseUrl === 'https://api.minimax.io/v1', 'minimax baseUrl should be https://api.minimax.io/v1');
+	assert(minimax.isOpenAICompatible === true, 'minimax should be OpenAI compatible');
+	assert(minimax.userModel === 'MiniMax-M2.7', 'minimax default model should be MiniMax-M2.7');
+
+	// Model list checks
+	const models: string[] = minimax.models;
+	assert(models.includes('MiniMax-M2.7'), 'minimax should include MiniMax-M2.7');
+	assert(models.includes('MiniMax-M2.7-highspeed'), 'minimax should include MiniMax-M2.7-highspeed');
+	assert(models.includes('MiniMax-M2.5'), 'minimax should include MiniMax-M2.5');
+	assert(models.includes('MiniMax-M2.5-highspeed'), 'minimax should include MiniMax-M2.5-highspeed');
+	assert(models.length === 4, 'minimax should have exactly 4 models');
+
+	// Website
+	assert(minimax.website === 'https://www.minimaxi.com', 'minimax website should be correct');
+
+	// Provider
+	assert(minimax.provider === 'MiniMax', 'minimax provider field should be "MiniMax"');
+}
+
+// ── Ordering: MiniMax should appear before OpenRouter ────────────────
+
+const minimaxIdx = llms.findIndex(l => l.id === 'minimax');
+const openrouterIdx = llms.findIndex(l => l.id === 'openrouter');
+assert(minimaxIdx < openrouterIdx, 'minimax should appear before openrouter in the list');
+
+// ── Summary ──────────────────────────────────────────────────────────
+
+console.log(`\nLLM provider tests: ${passed} passed, ${failed} failed`);
+if (failed > 0) {
+	process.exit(1);
+} else {
+	console.log('All tests passed!');
+}

--- a/service/src/hook/llm.ts
+++ b/service/src/hook/llm.ts
@@ -132,6 +132,18 @@ export const llms = [
 		userModel: 'moonshot-v1-8k'
 	},
 	{
+		id: 'minimax',
+		name: 'MiniMax',
+		baseUrl: 'https://api.minimax.io/v1',
+		models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+		provider: 'MiniMax',
+		isOpenAICompatible: true,
+		description: 'MiniMax large language models with 204K context window',
+		website: 'https://www.minimaxi.com',
+		userToken: '',
+		userModel: 'MiniMax-M2.7'
+	},
+	{
 		id: 'openrouter',
 		name: 'OpenRouter',
 		baseUrl: 'https://openrouter.ai/api/v1',


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimaxi.com) as a built-in LLM provider in OpenMCP. MiniMax exposes an OpenAI-compatible API at `https://api.minimax.io/v1`, so it works seamlessly with the existing `openai` SDK client — no extra dependencies needed.

### Models added
| Model | Context Window | Notes |
|-------|---------------|-------|
| `MiniMax-M2.7` | 204K | Latest flagship model (default) |
| `MiniMax-M2.7-highspeed` | 204K | Faster variant |
| `MiniMax-M2.5` | 204K | Previous generation |
| `MiniMax-M2.5-highspeed` | 204K | Faster variant |

### Changes
- **`service/src/hook/llm.ts`** — Add MiniMax provider entry to the `llms` array (before OpenRouter)
- **`service/src/hook/llm.test.ts`** — Unit tests: 119 assertions covering all providers + MiniMax-specific validation
- **`service/src/hook/llm.integration.test.ts`** — Integration tests: non-streaming, streaming, and tool calling against MiniMax API
- **`service/package.json`** — Add `test:llm` and `test:llm:integration` scripts
- **`README.md` / `README.zh.md`** — List all supported providers including MiniMax

6 files changed, 240 additions, 3 deletions.