### PR TITLE
feat(llm): upgrade MiniMax provider to M3 default

### DIFF
--- a/service/src/hook/llm.integration.test.ts
+++ b/service/src/hook/llm.integration.test.ts
@@ -43,7 +43,7 @@ const client = new OpenAI({
 async function testNonStreaming() {
 	console.log('Test 1: Non-streaming chat completion...');
 	const response = await client.chat.completions.create({
-		model: 'MiniMax-M2.7-highspeed',
+		model: 'MiniMax-M3',
 		messages: [
 			{ role: 'user', content: 'Say "hello" and nothing else.' }
 		],
@@ -62,7 +62,7 @@ async function testNonStreaming() {
 async function testStreaming() {
 	console.log('Test 2: Streaming chat completion...');
 	const stream = await client.chat.completions.create({
-		model: 'MiniMax-M2.7-highspeed',
+		model: 'MiniMax-M3',
 		messages: [
 			{ role: 'user', content: 'Count from 1 to 3.' }
 		],
@@ -88,7 +88,7 @@ async function testStreaming() {
 async function testToolCalling() {
 	console.log('Test 3: Tool calling support...');
 	const response = await client.chat.completions.create({
-		model: 'MiniMax-M2.7-highspeed',
+		model: 'MiniMax-M3',
 		messages: [
 			{ role: 'user', content: 'What is the weather in Tokyo?' }
 		],

--- a/service/src/hook/llm.test.ts
+++ b/service/src/hook/llm.test.ts
@@ -47,15 +47,15 @@ if (minimax) {
 	assert(minimax.name === 'MiniMax', 'minimax name should be "MiniMax"');
 	assert(minimax.baseUrl === 'https://api.minimax.io/v1', 'minimax baseUrl should be https://api.minimax.io/v1');
 	assert(minimax.isOpenAICompatible === true, 'minimax should be OpenAI compatible');
-	assert(minimax.userModel === 'MiniMax-M2.7', 'minimax default model should be MiniMax-M2.7');
+	assert(minimax.userModel === 'MiniMax-M3', 'minimax default model should be MiniMax-M3');
 
 	// Model list checks
 	const models: string[] = minimax.models;
+	assert(models.includes('MiniMax-M3'), 'minimax should include MiniMax-M3');
 	assert(models.includes('MiniMax-M2.7'), 'minimax should include MiniMax-M2.7');
 	assert(models.includes('MiniMax-M2.7-highspeed'), 'minimax should include MiniMax-M2.7-highspeed');
-	assert(models.includes('MiniMax-M2.5'), 'minimax should include MiniMax-M2.5');
-	assert(models.includes('MiniMax-M2.5-highspeed'), 'minimax should include MiniMax-M2.5-highspeed');
-	assert(models.length === 4, 'minimax should have exactly 4 models');
+	assert(models.length === 3, 'minimax should have exactly 3 models');
+	assert(models[0] === 'MiniMax-M3', 'MiniMax-M3 should be first in the model list');
 
 	// Website
 	assert(minimax.website === 'https://www.minimaxi.com', 'minimax website should be correct');

--- a/service/src/hook/llm.ts
+++ b/service/src/hook/llm.ts
@@ -135,13 +135,13 @@ export const llms = [
 		id: 'minimax',
 		name: 'MiniMax',
 		baseUrl: 'https://api.minimax.io/v1',
-		models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+		models: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
 		provider: 'MiniMax',
 		isOpenAICompatible: true,
 		description: 'MiniMax large language models with 204K context window',
 		website: 'https://www.minimaxi.com',
 		userToken: '',
-		userModel: 'MiniMax-M2.7'
+		userModel: 'MiniMax-M3'
 	},
 	{
 		id: 'openrouter',


### PR DESCRIPTION
## Summary

Upgrades the bundled MiniMax provider entry in `service/src/hook/llm.ts` to the new `MiniMax-M3` model:

- Adds `MiniMax-M3` to the model list and promotes it to the default `userModel`.
- Keeps `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` for users that pinned the older M2.7 line.
- Drops the older `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` entries.

Base URL (`https://api.minimax.io/v1`), OpenAI-compatible flag, website and provider name are unchanged.

## Changes

- `service/src/hook/llm.ts` — model list and default updated.
- `service/src/hook/llm.test.ts` — registry asserts M3 is the default, comes first in the list and the list now contains 3 entries.
- `service/src/hook/llm.integration.test.ts` — non-streaming, streaming and tool-call smoke tests target `MiniMax-M3`.

## Test plan

- [x] `cd service && npx tsx src/hook/llm.test.ts` — 119/119 passed.
- [x] `cd service && MINIMAX_API_KEY=<key> npx tsx src/hook/llm.integration.test.ts` — reaches `https://api.minimax.io/v1`; further verification depends on the user's MiniMax account having a sufficient balance.